### PR TITLE
chore(deps): upgrade jq to 1.8.2

### DIFF
--- a/jq/toolchain/platforms.bzl
+++ b/jq/toolchain/platforms.bzl
@@ -53,7 +53,7 @@ def _jq_platform_repo_impl(rctx):
     meta = JQ_PLATFORMS[rctx.attr.platform]
     release_platform = meta.release_platform if hasattr(meta, "release_platform") else rctx.attr.platform
 
-    url = "https://github.com/stedolan/jq/releases/download/jq-{0}/jq-{1}{2}".format(
+    url = "https://github.com/jqlang/jq/releases/download/jq-{0}/jq-{1}{2}".format(
         rctx.attr.version,
         release_platform,
         ".exe" if is_windows else "",

--- a/jq/toolchain/toolchain.bzl
+++ b/jq/toolchain/toolchain.bzl
@@ -5,7 +5,7 @@ load(":platforms.bzl", "JQ_PLATFORMS")
 
 TOOLCHAIN_TYPE = "@jq.bzl//jq/toolchain:type"
 DEFAULT_JQ_REPOSITORY = "jq"
-DEFAULT_JQ_VERSION = "1.7"
+DEFAULT_JQ_VERSION = "1.8.2"
 
 JqInfo = provider(
     doc = "Provide info for executing jq",

--- a/jq/toolchain/versions.bzl
+++ b/jq/toolchain/versions.bzl
@@ -1,15 +1,15 @@
-"""https://github.com/stedolan/jq/releases
+"""https://github.com/jqlang/jq/releases
 
 The integrity hashes can be computed with
 shasum -b -a 384 [downloaded file] | awk '{ print $1 }' | xxd -r -p | base64
 """
 JQ_VERSIONS = {
-    "1.7": {
-        "linux-amd64": "sha384-4wJ15NoxFf7r1Zf5YVGUeMPx/pfWlSfMJWLFcu4fUcBFe5L4BOpF/njEK8AH58od",
-        "linux-arm64": "sha384-y9BwX+RyXf2a16xwtvcjHFfIBp3K3Ukyg4GjtmxBtynD/BKNf+0tuLtZx64TTI+/",
-        "linux-riscv64": "sha384-mU7uq/gjpj7pDl9rqM1bcPvyqfi/+yfqnb1Jdp26bzQ5oXvZDn39eeJ8hla2nUaV",
-        "macos-amd64": "sha384-N0WdpiD8zl1k9888yGxWW/dHzztOTU+RTlZrzOYJMXXUUMqjnqXq8GwnHDsC9Lk3",
-        "macos-arm64": "sha384-0nnKlrEAU7NCzTM63XYkhAGGapA/IT2O2jkU+H+ZbQFu3E+XEbgw5E/+o0oHjLGf",
-        "win64": "sha384-2QfBgUpi1I5KPVrKtZnPcur+Wn/iE+tZVPFKXiIPoBKTpqZKhzc/CdqjcBn+IPiy",
+    "1.8.2": {
+        "linux-amd64": "sha384-THcFEVKSAQoeKYKNLpHotOsHpVElzghHC1Yl1dAUDSzn2aCKyTJuY9LjBTLl0v28",
+        "linux-arm64": "sha384-dVEFiMskmbPJB7Qeyzhh+teMzOxRSK3GChmkzWSq7HgoeWCIbRdcO4H8u6g7aSbF",
+        "linux-riscv64": "sha384-N6uq6S57QhUnSeEq3OtA2jcUndx1GHQjlsfSvzyXOnLjIV/yiGDH4JtblJ8tyG8x",
+        "macos-amd64": "sha384-LNcX+wzOt3/KaZi5JxNoJz2FKNHlupM9WN1FzDc+PUbbEsG0hPzH6JBCK6oxl70w",
+        "macos-arm64": "sha384-v5dCjZI/RAgEhhAURV+HdHV7G0sajQoS6zXxa9itJPPk8kX8GbUxgA97mvcUq24R",
+        "win64": "sha384-H+uQQ+llHv00+Nu7ehjTu83rAq9rmMx6uu28lpp9h5JXWjlz6KcQaAR473uv5VUR",
     },
 }


### PR DESCRIPTION
- Upgrade the default jq release from 1.7 to 1.8.2
- Update jq release URLs to the current canonical GitHub repo, jqlang/jq; the official jq download docs clone from https://github.com/jqlang/jq.git, and the old stedolan/jq URL redirects there. (jqlang.org (https://jqlang.org/download/)) (github.com (https://github.com/stedolan/jq))

## Validation

```
$ pre-commit run --all-files && bazel test //... && (cd e2e/smoke && bazel test //...)
[WARNING] top-level `default_stages` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
Check hooks apply to the repository......................................Passed
Check for useless excludes...............................................Passed
check that executables have shebangs.....................................Passed
check that scripts with shebangs are executable..........................Passed
check toml...............................................................Passed
check yaml...............................................................Passed
detect destroyed symlinks................................................Passed
detect private key.......................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
buildifier...............................................................Passed
buildifier-lint..........................................................Passed
prettier.................................................................Passed
yamlfmt..................................................................Passed
typos....................................................................Passed
INFO: Analyzed 46 targets (2 packages loaded, 63 targets configured).
INFO: Found 34 targets and 12 test targets...
INFO: Elapsed time: 1.632s, Critical Path: 0.02s
INFO: 1 process: 73 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
//jq/tests:case_data_input_flag_test                            (cached) PASSED in 2.1s
//jq/tests:case_dot_filter_test                                 (cached) PASSED in 3.9s
//jq/tests:case_filter_file_test                                (cached) PASSED in 3.2s
//jq/tests:case_genrule_test                                    (cached) PASSED in 0.5s
//jq/tests:case_jq_test                                         (cached) PASSED in 3.8s
//jq/tests:case_merge_filter_test                               (cached) PASSED in 0.7s
//jq/tests:case_no_sources_test                                 (cached) PASSED in 1.0s
//jq/tests:case_null_input_flag_test                            (cached) PASSED in 2.7s
//jq/tests:case_predeclared_output_test                         (cached) PASSED in 3.6s
//jq/tests:case_raw_input_test                                  (cached) PASSED in 1.3s
//jq/tests:check_stamped                                        (cached) PASSED in 4.1s
//jq/tests:check_unstamped                                      (cached) PASSED in 3.1s

Executed 0 out of 12 tests: 12 tests pass.
INFO: Analyzed 5 targets (2 packages loaded, 53 targets configured).
INFO: Found 3 targets and 2 test targets...
INFO: Elapsed time: 0.716s, Critical Path: 0.02s
INFO: 1 process: 12 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
//:jq_bin_test                                                  (cached) PASSED in 0.5s
//:smoke_test                                                   (cached) PASSED in 0.4s

Executed 0 out of 2 tests: 2 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```
