### PR TITLE
feat: expose jq host binary

### DIFF
--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -19,8 +19,7 @@ jq_test(
 sh_test(
     name = "jq_bin_test",
     srcs = ["tests/jq_bin.sh"],
-    data = ["@jq_toolchains//:resolved_toolchain"],
-    env = {"JQ_BIN": "$(JQ_BIN)"},
-    toolchains = ["@jq_toolchains//:resolved_toolchain"],
+    data = ["@jq"],
+    env = {"JQ_BIN": "$(rlocationpath @jq//:jq)"},
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -7,4 +7,4 @@ local_path_override(
 )
 
 toolchains = use_extension("@jq.bzl//jq:extensions.bzl", "toolchains")
-use_repo(toolchains, "jq_toolchains")
+use_repo(toolchains, "jq", "jq_toolchains")

--- a/jq/extensions.bzl
+++ b/jq/extensions.bzl
@@ -4,10 +4,10 @@ load("//jq/toolchain:platforms.bzl", "JQ_PLATFORMS", "jq_platform_repo")
 load("//jq/toolchain:toolchain.bzl", "DEFAULT_JQ_VERSION", "jq_host_alias_repo", "jq_toolchains_repo")
 
 def _toolchains_extension(module_ctx):
-    jq_toolchains_repo(name = "jq_toolchains", user_repository_name = "jq_toolchains")
+    jq_toolchains_repo(name = "jq_toolchains", user_repository_name = "jq")
     for platform in JQ_PLATFORMS.keys():
         jq_platform_repo(
-            name = "{}_{}".format("jq_toolchains", platform),
+            name = "{}_{}".format("jq", platform),
             platform = platform,
             version = DEFAULT_JQ_VERSION,
         )


### PR DESCRIPTION
- align generated platform repository names with the existing `@jq//:jq` host alias
- keep the `jq_toolchains` repository for toolchain registration
- update the smoke module to validate direct `@jq//:jq` consumption

## Validation

```
$ pre-commit run --all-files && bazel test //... && (cd e2e/smoke && bazel test //...) && bazel run @jq//:jq -- --version
[WARNING] top-level `default_stages` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
Check hooks apply to the repository......................................Passed
Check for useless excludes...............................................Passed
check that executables have shebangs.....................................Passed
check that scripts with shebangs are executable..........................Passed
check toml...............................................................Passed
check yaml...............................................................Passed
detect destroyed symlinks................................................Passed
detect private key.......................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
buildifier...............................................................Passed
buildifier-lint..........................................................Passed
prettier.................................................................Passed
yamlfmt..................................................................Passed
typos....................................................................Passed
INFO: Analyzed 46 targets (114 packages loaded, 1215 targets configured).
INFO: Found 34 targets and 12 test targets...
INFO: Elapsed time: 1.186s, Critical Path: 0.05s
INFO: 1 process: 101 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
//jq/tests:case_data_input_flag_test                            (cached) PASSED in 0.2s
//jq/tests:case_dot_filter_test                                 (cached) PASSED in 0.4s
//jq/tests:case_filter_file_test                                (cached) PASSED in 0.2s
//jq/tests:case_genrule_test                                    (cached) PASSED in 2.7s
//jq/tests:case_jq_test                                         (cached) PASSED in 0.2s
//jq/tests:case_merge_filter_test                               (cached) PASSED in 0.2s
//jq/tests:case_no_sources_test                                 (cached) PASSED in 0.2s
//jq/tests:case_null_input_flag_test                            (cached) PASSED in 0.2s
//jq/tests:case_predeclared_output_test                         (cached) PASSED in 0.6s
//jq/tests:case_raw_input_test                                  (cached) PASSED in 0.2s
//jq/tests:check_stamped                                        (cached) PASSED in 0.4s
//jq/tests:check_unstamped                                      (cached) PASSED in 0.6s

Executed 0 out of 12 tests: 12 tests pass.
INFO: Analyzed 5 targets (0 packages loaded, 0 targets configured).
INFO: Found 3 targets and 2 test targets...
INFO: Elapsed time: 0.279s, Critical Path: 0.02s
INFO: 1 process: 2 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
//:jq_bin_test                                                  (cached) PASSED in 0.7s
//:smoke_test                                                   (cached) PASSED in 0.5s

Executed 0 out of 2 tests: 2 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
INFO: Analyzed target @@jq.bzl++toolchains+jq//:jq (0 packages loaded, 0 targets configured).
WARNING: /Users/afarbos/Library/Caches/bazel/_bazel_afarbos/aac6e37fb65f4e19f039e48e853bb60b/external/jq.bzl++toolchains+jq/BUILD.bazel:3:14: @@jq.bzl++toolchains+jq//:jq is a source file, nothing will be built for it. If you want to build a target that consumes this file, try --compile_one_dependency
INFO: Found 1 target...
INFO: Elapsed time: 0.115s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: /Users/afarbos/Library/Caches/bazel/_bazel_afarbos/aac6e37fb65f4e19f039e48e853bb60b/external/jq.bzl++toolchains+jq/jq <args omitted>
jq-1.7
```